### PR TITLE
Respect compiler flags from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .POSIX:
-CC      = cc
-CFLAGS  = -std=c99 -Wall -Wextra -Wno-missing-field-initializers -Os
-LDFLAGS = -ggdb3
-LDLIBS  =
+CC      ?= cc
+CFLAGS  ?= -Os
+CFLAGS  += -std=c99 -Wall -Wextra -Wno-missing-field-initializers
+LDFLAGS ?= -ggdb3
+LDLIBS  ?=
 
 endlessh: endlessh.c
 	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ endlessh.c $(LDLIBS)


### PR DESCRIPTION
Make build more packaging friendly by respecting CC/CFLAGS/LDFLAGS set by user or packaging system