### PR TITLE
Added -4 -6 Switches and default tcp46 fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Usage information is printed with `-h`.
 
 ```
 Usage: endlessh [-vh] [-d MS] [-f CONFIG] [-l LEN] [-m LIMIT] [-p PORT]
+  -4        Bind to IPv4 only
+  -6        Bind to IPv6 only
   -d INT    Message millisecond delay [10000]
   -f        Set and load config file [/etc/endlessh/config]
   -h        Print this help message and exit
@@ -69,6 +71,12 @@ MaxClients 4096
 #   1 = Standard, useful log messages
 #   2 = Very noisy debugging information
 LogLevel 0
+
+# Set the family of the listening socket
+#   0 = Use IPv4 Mapped IPv6 (Both v4 and v6, default)
+#   4 = Use IPv4 only
+#   6 = Use IPv6 only
+BindFamily 0
 ```
 
 ## Build issues

--- a/util/smf/endlessh.conf
+++ b/util/smf/endlessh.conf
@@ -19,3 +19,9 @@ MaxClients 4096
 #   1 = Standard, useful log messages
 #   2 = Very noisy debugging information
 LogLevel 1
+
+# Set the family of the listening socket
+#   0 = Use IPv4 Mapped IPv6 (Both v4 and v6, default)
+#   4 = Use IPv4 only
+#   6 = Use IPv6 only
+BindFamily 0


### PR DESCRIPTION
See #13 for more information

As *BSD defaults to use IPv6 only sockets and Linux to IPv4 mapped IPv6
sockets, switches to support explicit binding address families are required.

Now set explicitly if you want IPv6 only, IPv4 only or mapped IPv4.

Caveat:
OpenBSD explicitly states to not support IPv4 mapped IPv6 via setsock-API

### Discussions needed:

1) Configuration Naming okay?
2) Is a specific ipv4 mapped ipv6 switch needed?
3) Default to IPv6Only to be compliant with OpenBSD?
4) Has Solaris IPV6_V6ONLY sockopt?

### Reasoning
1) First I've come up with
2) Didn't include one as other software also doesn't do this and would complicate option parsing further
3) Normally you want to listen on v4 v6 anyway, was default behaviour in previous version.
    Doing A on Linux and B on *BSD as default would complicate code and UX.
4) {Net,Open,Free}-BSD has it, Illumos has it, chances are high


Tested on Arch Linux (Linux 5.0.5), Ubuntu 18.{04,10}, Ubuntu 16.04 and FreeBSD 12 (fresh VM install)