### PR TITLE
Prevent access to /run and /var in endlessh.service

### DIFF
--- a/util/endlessh.service
+++ b/util/endlessh.service
@@ -21,6 +21,7 @@ PrivateTmp=true
 PrivateDevices=true
 ProtectSystem=full
 ProtectHome=true
+InaccessiblePaths=/run /var
 
 ## If you want Endlessh to bind on ports < 1024
 ## 1) run: 


### PR DESCRIPTION
This hedges against a vulnerability in endlessh, by limiting exposure of sensitive files.
(In the same way that `Private{Tmp,Devices}` and `Protect{System,Home}` are already used.)