### PR TITLE
Add support for socket activation

### DIFF
--- a/endlessh.c
+++ b/endlessh.c
@@ -312,6 +312,7 @@ struct config {
     .bind_family     = DEFAULT_BIND_FAMILY, \
 }
 
+static bool port_set = false;
 static void
 config_set_port(struct config *c, const char *s, int hardfail)
 {
@@ -325,6 +326,7 @@ config_set_port(struct config *c, const char *s, int hardfail)
     } else {
         c->port = tmp;
     }
+    port_set = true;
 }
 
 static void
@@ -702,6 +704,12 @@ main(int argc, char **argv)
     if (argv[optind]) {
         fprintf(stderr, "endlessh: too many arguments\n");
         exit(EXIT_FAILURE);
+    }
+
+    if (listen_on_stdin && port_set) {
+      fprintf(stderr, "endlessh: Cannot specify a port "
+              "when listening on stdin (-i)\n");
+      exit(EXIT_FAILURE);
     }
 
     if (logmsg == logsyslog) {

--- a/util/endlessh@.service
+++ b/util/endlessh@.service
@@ -9,6 +9,7 @@ Restart=always
 RestartSec=30sec
 ExecStart=/usr/local/bin/endlessh -i
 KillSignal=SIGTERM
+DynamicUser=true
 
 # Stop trying to restart the service if it restarts too many times in a row
 StartLimitInterval=5min
@@ -18,16 +19,15 @@ StandardOutput=journal
 StandardError=journal
 StandardInput=socket
 
-DynamicUser=true
-
+PrivateTmp=true
 PrivateDevices=true
 PrivateNetwork=true
 ProtectSystem=full
 ProtectHome=true
 InaccessiblePaths=/run /var
+PrivateUsers=true
 NoNewPrivileges=true
 ConfigurationDirectory=endlessh
-PrivateUsers=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/util/endlessh@.service
+++ b/util/endlessh@.service
@@ -33,6 +33,9 @@ ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true
 MemoryDenyWriteExecute=true
+SystemCallArchitectures=native
+SystemCallFilter=@basic-io @file-system @io-event @network-io @signal
+SystemCallFilter=arch_prctl brk mprotect ~socket
 
 [Install]
 WantedBy=multi-user.target

--- a/util/endlessh@.service
+++ b/util/endlessh@.service
@@ -32,6 +32,10 @@ ProtectKernelLogs=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+
+LockPersonality=true
 MemoryDenyWriteExecute=true
 SystemCallArchitectures=native
 SystemCallFilter=@basic-io @file-system @io-event @network-io @signal

--- a/util/endlessh@.service
+++ b/util/endlessh@.service
@@ -28,6 +28,7 @@ InaccessiblePaths=/run /var
 PrivateUsers=true
 NoNewPrivileges=true
 ConfigurationDirectory=endlessh
+ProtectKernelLogs=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/util/endlessh@.service
+++ b/util/endlessh@.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Endlessh SSH Tarpit
+Documentation=man:endlessh(1)
+Requires=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=30sec
+ExecStart=/usr/local/bin/endlessh -i
+KillSignal=SIGTERM
+
+# Stop trying to restart the service if it restarts too many times in a row
+StartLimitInterval=5min
+StartLimitBurst=4
+
+StandardOutput=journal
+StandardError=journal
+StandardInput=socket
+
+DynamicUser=true
+
+PrivateDevices=true
+PrivateNetwork=true
+ProtectSystem=full
+ProtectHome=true
+InaccessiblePaths=/run /var
+NoNewPrivileges=true
+ConfigurationDirectory=endlessh
+PrivateUsers=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target

--- a/util/endlessh@.socket
+++ b/util/endlessh@.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Endlessh SSH Tarpit socket
+Documentation=man:endlessh(1)
+
+[Socket]
+ListenStream=%i
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
- [x] endlessh: Add a new option (`-i`) to expect a socket on `stdin`.
- [x] systemd: Add two templated unit files (`endlessh@.{service,socket}`)
      to support socket activation on arbitrary ports.
- [x] endlessh: Error-out when `-i` is specified on the command-line and a port
      was explicitely configured (either by config file or CLI argument).
- [ ] systemd: Rework the default service (`endlessh.service`) to use socket
      activation, or remove it outright.

### Rationale

- Supports listening on port 22 without issue. (see #39)
- Lowers overhead, as the service isn't started until the first connection.
- Improves security, as the socket-activated service:
  - runs under a transient user (not root!), even with ports <1024;
  - does not have any access to the network, aside from the socket it was
    started with.