### PR TITLE
Makefile: Use implicit rules for compiling C, honour flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ PREFIX  = /usr/local
 
 all: endlessh
 
-endlessh: endlessh.c
-	$(CC) $(LDFLAGS) $(CFLAGS) -o $@ endlessh.c $(LDLIBS)
-
 install: endlessh
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m 755 endlessh $(DESTDIR)$(PREFIX)/bin/


### PR DESCRIPTION
In addition to being shorter, this does the right thing with regards to
honouring various flags: not only `CFLAGS` and `LDFLAGS`, but also `CPPFLAGS`.

`CPPFLAGS` are the flags passed to `cpp` (the C PreProcessor); for example,
we use `-D_FORTIFY_SOURCE=2` in Debian for build hardening.