### PR TITLE
Consistent usage messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ trap multiple clients at a time.
 Usage information is printed with `-h`.
 
 ```
-Usage: endlessh [-vhs] [-d MS] [-f CONFIG] [-l LEN] [-m LIMIT] [-p PORT]
+Usage: endlessh [-vVhs] [-46] [-d MS] [-f CONFIG] [-l LEN] [-m LIMIT] [-p PORT]
   -4        Bind to IPv4 only
   -6        Bind to IPv6 only
   -d INT    Message millisecond delay [10000]
@@ -27,6 +27,7 @@ Usage: endlessh [-vhs] [-d MS] [-f CONFIG] [-l LEN] [-m LIMIT] [-p PORT]
   -p INT    Listening port [2222]
   -s        Print diagnostics to syslog instead of standard output
   -v        Print diagnostics (repeatable)
+  -V        Print version information and exit
 ```
 
 Argument order matters. The configuration file is loaded when the `-f`

--- a/endlessh.c
+++ b/endlessh.c
@@ -516,8 +516,8 @@ config_log(const struct config *c)
 static void
 usage(FILE *f)
 {
-    fprintf(f, "Usage: endlessh [-vh] [-46] [-d MS] [-f CONFIG] [-l LEN] "
-                               "[-m LIMIT] [-p PORT]\n");
+    fprintf(f, "Usage: endlessh [-vVhs] [-46] [-d MS] [-f CONFIG] [-l LEN] "
+            "[-m LIMIT] [-p PORT]\n");
     fprintf(f, "  -4        Bind to IPv4 only\n");
     fprintf(f, "  -6        Bind to IPv6 only\n");
     fprintf(f, "  -d INT    Message millisecond delay ["
@@ -530,6 +530,8 @@ usage(FILE *f)
     fprintf(f, "  -m INT    Maximum number of clients ["
             XSTR(DEFAULT_MAX_CLIENTS) "]\n");
     fprintf(f, "  -p INT    Listening port [" XSTR(DEFAULT_PORT) "]\n");
+    fprintf(f, "  -s        Print diagnostics to syslog instead of "
+            "standard output\n");
     fprintf(f, "  -v        Print diagnostics to standard output "
             "(repeatable)\n");
     fprintf(f, "  -V        Print version information and exit\n");


### PR DESCRIPTION
Sorry, I have another Christmas PR. I just noticed that the usage messages are not consistent between the README and endless.c so... Fixed?