### PR TITLE
Add meson build support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,6 @@
+project('endlessh', 'c')
+
+src = 'endlessh.c'
+executable('endlessh', src)
+
+install_man('endlessh.1')


### PR DESCRIPTION
Distributions like Debian or Fedora are patching `Makefile` to adapt to their distro needs. This simple Meson recipe would avoid those changes without adding much change, easing path and flags configuration, and can co-exist with current `Makefile`.