### PR TITLE
Misc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .POSIX:
 CC       = cc
-CFLAGS   = -std=c99 -Wall -Wextra -Wno-missing-field-initializers -Os
+WARNINGS = -Wall -Wcast-align -Wcast-qual -Wextra -Wfloat-equal -Wformat=2 -Winit-self -Wmissing-format-attribute -Wmissing-noreturn -Wmissing-prototypes -Wnull-dereference -Wpointer-arith -Wshadow -Wstrict-prototypes -Wundef -Wunused -Wwrite-strings
+CFLAGS   = -std=c99 $(WARNINGS) -Os
 CPPFLAGS =
 LDFLAGS  = -ggdb3
 LDLIBS   =

--- a/endlessh.c
+++ b/endlessh.c
@@ -244,6 +244,7 @@ fifo_destroy(struct fifo *q)
 }
 
 static void
+__attribute__((noreturn))
 die(void)
 {
     fprintf(stderr, "endlessh: fatal: %s\n", strerror(errno));

--- a/endlessh.c
+++ b/endlessh.c
@@ -182,7 +182,7 @@ client_destroy(struct client *client)
 }
 
 static void
-statistics_log_totals(struct client *clients)
+statistics_log_totals(const struct client *clients)
 {
     long long milliseconds = statistics.milliseconds;
     for (long long now = epochms(); clients; clients = clients->next)

--- a/endlessh.c
+++ b/endlessh.c
@@ -107,7 +107,7 @@ logsyslog(enum loglevel level, const char *format, ...)
     }
 }
 
-struct {
+static struct {
     long long connects;
     long long milliseconds;
     long long bytes_sent;

--- a/endlessh.c
+++ b/endlessh.c
@@ -58,7 +58,7 @@ static enum loglevel {
     log_debug
 } loglevel = log_none;
 
-static void (*logmsg)(enum loglevel level, const char *, ...) __attribute__((format (printf, 2, 3)));
+static void (*logmsg)(enum loglevel, const char *, ...) __attribute__((format (printf, 2, 3)));
 
 static void
 __attribute__((format (printf, 2, 3)))

--- a/endlessh.c
+++ b/endlessh.c
@@ -58,9 +58,10 @@ static enum loglevel {
     log_debug
 } loglevel = log_none;
 
-static void (*logmsg)(enum loglevel level, const char *, ...);
+static void (*logmsg)(enum loglevel level, const char *, ...) __attribute__((format (printf, 2, 3)));
 
 static void
+__attribute__((format (printf, 2, 3)))
 logstdio(enum loglevel level, const char *format, ...)
 {
     if (loglevel >= level) {
@@ -86,6 +87,7 @@ logstdio(enum loglevel level, const char *format, ...)
 }
 
 static void
+__attribute__((format (printf, 2, 3)))
 logsyslog(enum loglevel level, const char *format, ...)
 {
     static const int prio_map[] = { LOG_NOTICE, LOG_INFO, LOG_DEBUG };
@@ -504,7 +506,7 @@ static void
 config_log(const struct config *c)
 {
     logmsg(log_info, "Port %d", c->port);
-    logmsg(log_info, "Delay %ld", c->delay);
+    logmsg(log_info, "Delay %d", c->delay);
     logmsg(log_info, "MaxLineLength %d", c->max_line_length);
     logmsg(log_info, "MaxClients %d", c->max_clients);
     logmsg(log_info, "BindFamily %s",


### PR DESCRIPTION
*  Enable several compiler warnings
   Enable common compiler warnings supported by GCC and Clang.

* Add format attributes
   Enable compilers to check for format string issues.

   ```
   endlessh.c: In function ‘logstdio’:
   endlessh.c:80:9: warning: function ‘logstdio’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
      80 |         vprintf(format, ap);
         |         ^~~~~~~
   endlessh.c: In function ‘logsyslog’:
   endlessh.c1009: warning: function ‘logsyslog’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
     100 |         vsnprintf(buf, sizeof buf, format, ap);
         |         ^~~~~~~~~

   endlessh.c: In function ‘config_log’:
   endlessh.c:509:31: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int’ [-Wformat=]
     509 |     logmsg(log_info, "Delay %ld", c->delay);
         |                             ~~^   ~~~~~~~~
         |                               |    |
         |                               |    int
         |                               long int
         |                             %d
   ```

* Drop unnecessary parameter name in function typedef

* Mark file local statistics struct static

* Mark die() as noreturn
   die() calls exit() and thus never returns.

   ```
   endlessh.c:248:1: warning: function 'die' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
   {
   ^
   ```

* Mark client parameter of statistics_log_totals const
   statistics_log_totals() does not modify any state.

* Use unsigned data types
   Use unsigned data types for counters containing only non-negative values to ensure, i.e. on a long-running endlessh instance, potential wrap-arounds are well-defined.

