### PR TITLE
Fast deploy

### DIFF
--- a/studious-fast/endlessh-deploy-on-port.py
+++ b/studious-fast/endlessh-deploy-on-port.py
@@ -12,17 +12,17 @@ args = parser.parse_args()
 #
 # READ PRESETS DATA
 script_endlessh_preset1, service_endlessh_preset1 = "", ""
-with open("endlessh-call-port_N.service$",'rb') as FileRead_in1_KC:
+with open("presets/endlessh-call-port_N.service$",'rb') as FileRead_in1_KC:
     service_endlessh_preset1 = FileRead_in1_KC.read().decode()
     FileRead_in1_KC.close()
 # 
-with open("endlessh-script-port_N.sh$",'rb') as FileRead_in1_KC:
+with open("presets/endlessh-script-port_N.sh$",'rb') as FileRead_in1_KC:
     script_endlessh_preset1 = FileRead_in1_KC.read().decode()
     FileRead_in1_KC.close()
 # ~~~
 # Get Endlessh port from argparsing
-if args.endlessh_port: # args setted fine.
-    endlessh_port = args.endlessh_port
+if args.port: # args setted fine.
+    endlessh_port = args.port
 else: # no args setted... so default set to (port: 22)...
     endlessh_port = 22
 #
@@ -48,18 +48,18 @@ script_endlessh_preset1 = script_endlessh_preset1.format(
 with open("{service_endlessh_path}/{service_endlessh_filename}".format(
         service_endlessh_path = service_endlessh_path,
         service_endlessh_filename = service_endlessh_filename
-    ), 'rb') as f_out_re:
-    f_out_re.write(service_endlessh_preset1)
+    ), 'wb') as f_out_re:
+    f_out_re.write(service_endlessh_preset1.encode())
     f_out_re.close()
 #
 with open("{script_endlessh_path}/{script_endlessh_filename}".format(
         script_endlessh_path = script_endlessh_path,
         script_endlessh_filename = script_endlessh_filename
-    ), 'rb') as f_out_re:
-    f_out_re.write(script_endlessh_preset1)
+    ), 'wb') as f_out_re:
+    f_out_re.write(script_endlessh_preset1.encode())
     f_out_re.close()
 # change execution right to use the launch script
 system("sudo chmod +x {}".format(script_endlessh_path+"/"+script_endlessh_filename))
 # enable & start the service of the endlessh deploy 
-system("sudo systemctl enable --now {service}".format(service = service_endlessh_filename))
+system("sudo systemctl enable --now {service} && sudo systemctl status {service}".format(service = service_endlessh_filename))
 exit(0)

--- a/studious-fast/endlessh-deploy-on-port.py
+++ b/studious-fast/endlessh-deploy-on-port.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+#coding: utf-8
+import argparse
+from os import system
+parser = argparse.ArgumentParser("Endlessh fast deploy preset tool | v1 - (Studious-Fast)")
+#
+# Args to set usages modes
+parser.add_argument("-p", "--port", type=int,
+                    help="Listening port [22].")
+#
+args = parser.parse_args()
+#
+# READ PRESETS DATA
+script_endlessh_preset1, service_endlessh_preset1 = "", ""
+with open("endlessh-call-port_N.service$",'rb') as FileRead_in1_KC:
+    service_endlessh_preset1 = FileRead_in1_KC.read().decode()
+    FileRead_in1_KC.close()
+# 
+with open("endlessh-script-port_N.sh$",'rb') as FileRead_in1_KC:
+    script_endlessh_preset1 = FileRead_in1_KC.read().decode()
+    FileRead_in1_KC.close()
+# ~~~
+# Get Endlessh port from argparsing
+if args.endlessh_port: # args setted fine.
+    endlessh_port = args.endlessh_port
+else: # no args setted... so default set to (port: 22)...
+    endlessh_port = 22
+#
+# ~~~
+# Destination path definition
+service_endlessh_path = "/etc/systemd/system"
+script_endlessh_path = "/opt"
+# Destination filename definition with using the port number inside the names
+service_endlessh_filename = "endlessh-call-p{port}.service".format(
+    port = endlessh_port
+)
+script_endlessh_filename = "endlessh-script-p{port}.sh".format(
+    port = endlessh_port
+)
+# Inject setting change port to the presets(in-mem)
+service_endlessh_preset1 = service_endlessh_preset1.format(
+    port_number = endlessh_port
+)
+script_endlessh_preset1 = script_endlessh_preset1.format(
+    port_number = endlessh_port
+)
+# Write Files on the system
+with open("{service_endlessh_path}/{service_endlessh_filename}".format(
+        service_endlessh_path = service_endlessh_path,
+        service_endlessh_filename = service_endlessh_filename
+    ), 'rb') as f_out_re:
+    f_out_re.write(service_endlessh_preset1)
+    f_out_re.close()
+#
+with open("{script_endlessh_path}/{script_endlessh_filename}".format(
+        script_endlessh_path = script_endlessh_path,
+        script_endlessh_filename = script_endlessh_filename
+    ), 'rb') as f_out_re:
+    f_out_re.write(script_endlessh_preset1)
+    f_out_re.close()
+# change execution right to use the launch script
+system("sudo chmod +x {}".format(script_endlessh_path+"/"+script_endlessh_filename))
+# enable & start the service of the endlessh deploy 
+system("sudo systemctl enable --now {service}".format(service = service_endlessh_filename))
+exit(0)

--- a/studious-fast/presets/endlessh-call-port_N.service$
+++ b/studious-fast/presets/endlessh-call-port_N.service$
@@ -8,6 +8,6 @@ Type=simple
 Restart=always
 RestartSec=15
 User=root
-ExecStart=/bin/bash /opt/endless-script-p{port_number}.sh
+ExecStart=/bin/bash /opt/endlessh-script-p{port_number}.sh
 [Install]
 WantedBy=multi-user.target

--- a/studious-fast/presets/endlessh-call-port_N.service$
+++ b/studious-fast/presets/endlessh-call-port_N.service$
@@ -1,0 +1,13 @@
+[Unit]
+Description=EndleSSH script call p{port_number}
+After=network.target
+StartLimitIntervalSec=30
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=15
+User=root
+ExecStart=/bin/bash /opt/endless-script-p{port_number}.sh
+[Install]
+WantedBy=multi-user.target

--- a/studious-fast/presets/endlessh-script-port_N.sh$
+++ b/studious-fast/presets/endlessh-script-port_N.sh$
@@ -1,0 +1,6 @@
+#!/bin/bash
+while :
+do
+    /usr/bin/endlessh -4 -d 5000 -l 128 -m 4096 -p {port_number} -s -v
+    sleep 60
+done


### PR DESCRIPTION
No time to be slow.
choose an port and done.

So I add an little tool...
```
python3 endlessh-deploy-on-port.py  -h
usage: Endlessh fast deploy preset tool | v1 - (Studious-Fast) [-h] [-p PORT]

optional arguments:
-h, --help            show this help message and exit
-p PORT, --port PORT  Listening port [22].
```