### PR TITLE
Makefile: add directory variables BINDIR and MANDIR to allow easier overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ CPPFLAGS =
 LDFLAGS  = -ggdb3
 LDLIBS   =
 PREFIX   = /usr/local
+BINDIR   = $(PREFIX)/bin
+MANDIR   = $(PREFIX)/share/man
 
 all: endlessh
 
@@ -12,10 +14,10 @@ endlessh: endlessh.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ endlessh.c $(LDLIBS)
 
 install: endlessh
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m 755 endlessh $(DESTDIR)$(PREFIX)/bin/
-	install -d $(DESTDIR)$(PREFIX)/share/man/man1
-	install -m 644 endlessh.1 $(DESTDIR)$(PREFIX)/share/man/man1/
+	install -d $(DESTDIR)$(BINDIR)
+	install -m 755 endlessh $(DESTDIR)$(BINDIR)/
+	install -d $(DESTDIR)$(MANDIR)/man1
+	install -m 644 endlessh.1 $(DESTDIR)$(MANDIR)/man1/
 
 clean:
 	rm -rf endlessh

--- a/README.md
+++ b/README.md
@@ -112,22 +112,6 @@ need to use `-D__EXTENSIONS__` in `CFLAGS`.
 
 The man page needs to go into a different path for OpenBSD's `man` command:
 
-```
-diff --git a/Makefile b/Makefile
-index 119347a..dedf69d 100644
---- a/Makefile
-+++ b/Makefile
-@@ -14,8 +14,8 @@ endlessh: endlessh.c
- install: endlessh
-        install -d $(DESTDIR)$(PREFIX)/bin
-        install -m 755 endlessh $(DESTDIR)$(PREFIX)/bin/
--       install -d $(DESTDIR)$(PREFIX)/share/man/man1
--       install -m 644 endlessh.1 $(DESTDIR)$(PREFIX)/share/man/man1/
-+       install -d $(DESTDIR)$(PREFIX)/man/man1
-+       install -m 644 endlessh.1 $(DESTDIR)$(PREFIX)/man/man1/
-
- clean:
-        rm -rf endlessh
-```
+    make MANDIR=/usr/local/man install
 
 [np]: https://nullprogram.com/blog/2019/03/22/


### PR DESCRIPTION
This should remove the need to patch the Makefile on OpenBSD.