### PR TITLE
Increase max configurable line length from config

### DIFF
--- a/endlessh.c
+++ b/endlessh.c
@@ -362,7 +362,7 @@ config_set_max_line_length(struct config *c, const char *s, int hardfail)
     errno = 0;
     char *end;
     long tmp = strtol(s, &end, 10);
-    if (errno || *end || tmp < 3 || tmp > 255) {
+    if (errno || *end || tmp < 3 || tmp > 4096) {
         fprintf(stderr, "endlessh: Invalid line length: %s\n", s);
         if (hardfail)
             exit(EXIT_FAILURE);


### PR DESCRIPTION
Because the SSH spec doesn't mention any max length of the banner size, it can be assumed that line lengths aren't checked, either. In this case, increasing the max line length (from config) may cause buffer overflows in systems attempting to gain access to servers running this tarpit. Causing buffer overflows in bot systems is a non-issue, and personally I'd encourage it.

If it leads to system instability, fine by me and I'm sure many others will agree.

