### PR TITLE
Failed to set up mount namespacing fix on LXC containers

### DIFF
--- a/util/endlessh.service
+++ b/util/endlessh.service
@@ -34,9 +34,14 @@ PrivateUsers=true
 
 NoNewPrivileges=true
 ConfigurationDirectory=endlessh
-ProtectKernelTunables=true
 ProtectKernelModules=true
+
+# If you are running Endlessh in a LXC container
+# And recieve a "Failed to set up mount namespacing" error
+# Comment these two lines
+ProtectKernelTunables=true
 ProtectControlGroups=true
+
 MemoryDenyWriteExecute=true
 
 [Install]


### PR DESCRIPTION
When running inside an unpriviledged LXC container, the `ProtectKernelTunables` and `ProtectControlGroups` result in the process not being able to start with `Failed to set up mount namespacing` issue.