### PR TITLE
Update Dockerfile Alpine to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
-FROM alpine:3.9 as builder
+FROM alpine:3.16 as builder
 RUN apk add --no-cache build-base
 ADD endlessh.c Makefile /
 RUN make
 
-
-FROM alpine:3.9
-
-COPY --from=builder /endlessh /
-
+FROM alpine:3.16
 EXPOSE 2222/tcp
-
 ENTRYPOINT ["/endlessh"]
-
 CMD ["-v"]
+COPY --from=builder /endlessh /


### PR DESCRIPTION
Also, moved copy instruction to the end to optime the build cache.