### PR TITLE
OpenRC service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-endlessh
+/endlessh

--- a/util/openrc/README.md
+++ b/util/openrc/README.md
@@ -1,0 +1,10 @@
+# Running `endlessh` on OpenRC
+
+OpenRC is used by Gentoo and Alpine.
+
+Add the provided service to `/etc/init.d`, enable and start it.
+
+```sh
+rc-update add endlessh
+rc-service endlessh start
+```

--- a/util/openrc/endlessh
+++ b/util/openrc/endlessh
@@ -1,0 +1,15 @@
+#!/sbin/openrc-run
+
+command=/usr/bin/endlessh
+supervisor="supervise-daemon"
+pidfile=/run/endlessh.pid
+
+depend() {
+        need net
+}
+
+reload() {
+        ebegin "Reloading endlessh"
+        ${supervisor} ${RC_SVCNAME} --signal HUP --pidfile "${pidfile}"
+        eend $?
+}


### PR DESCRIPTION
This PR adds an OpenRC service file which can be used on Gentoo and Alpine.

Additionally, I edited `.gitignore` to only ignore the built binary, and not the service files in this repo.