### PR TITLE
Feat: add support for systemd reload

### DIFF
--- a/util/endlessh.service
+++ b/util/endlessh.service
@@ -8,6 +8,7 @@ Type=simple
 Restart=always
 RestartSec=30sec
 ExecStart=/usr/local/bin/endlessh
+ExecReload=kill -s SIGHUP $MAINPID
 KillSignal=SIGTERM
 
 # Stop trying to restart the service if it restarts too many times in a row


### PR DESCRIPTION
Added `ExecReload` to service file, this allows users to use `systemctl reload endlessh` to reload config.