### PR TITLE
Make sure unveil(2) is properly locked

### DIFF
--- a/endlessh.c
+++ b/endlessh.c
@@ -633,6 +633,8 @@ main(int argc, char **argv)
     const char *config_file = DEFAULT_CONFIG_FILE;
 
 #if defined(__OpenBSD__)
+    if (unveil("/", "") == -1)
+        die();
     unveil(config_file, "r"); /* return ignored as the file may not exist */
     if (pledge("inet stdio rpath unveil", 0) == -1)
         die();
@@ -692,6 +694,11 @@ main(int argc, char **argv)
                 exit(EXIT_FAILURE);
         }
     }
+
+#if defined(__OpenBSD__)
+    if (unveil(0, 0) == -1)
+        die();
+#endif
 
     if (argv[optind]) {
         fprintf(stderr, "endlessh: too many arguments\n");


### PR DESCRIPTION
This change ensures that unveil always gets locked (by passing two NULL arguments) and at least one path ("/" with no permissions) got added to unveil before that.

When no existing paths were registered with unveil(2), the filesystem access is not restricted by it. Locking it in that state only prevents us from configuring it further.

<details>
<summary>Notes on what I tried out.</summary>

## Observations

Unveil gets locked, when we pass something via the '-f' flag. But it does not (or
only partially) when we do not.

### With custom config and no default config

```
$ touch empty.config
$ ktrace ./endlessh -f empty.config
^C
$ kdump | grep unveil
 81470 endlessh CALL  unveil(0x32be4cda6d7,0x32be4cda4ea)
 81470 endlessh RET   unveil -1 errno 2 No such file or directory
 81470 endlessh STRU  promise="inet stdio rpath unveil"
 81470 endlessh CALL  unveil(0x6fd5478a252e,0x32be4cda4ea)
 81470 endlessh RET   unveil 0
 81470 endlessh CALL  unveil(0,0)
 81470 endlessh RET   unveil 0
```

While `ps -O state` reports: `81470 I+pU   p4    0:00.00 ./endlessh -f empty.config`.

Notice the `U`. (this is good)

Quote of `ps(1)`:

> ```
> U       The process has unveiled, and unveil(2) is now
>         locked.
> u       The process has unveiled, but not yet locked
>         unveil(2) (could be a program error).
> ```

### Without custom config and no default config

```
$ ls /etc/endlessh
ls: /etc/endlessh: No such file or directory
$ ktrace ./endlessh
^C
$ kdump| grep unveil
 17997 endlessh CALL  unveil(0xf1b60b146d7,0xf1b60b144ea)
 17997 endlessh RET   unveil -1 errno 2 No such file or directory
 17997 endlessh STRU  promise="inet stdio rpath unveil"
```

While ps reports: `17997 S+p    p4    0:00.00 ./endlessh`.

Notice no `U` or `u`. (this is not good)

### Without custom config and the default config directory

```
# mkdir /etc/endlessh
$ ktrace ./endlessh
^C
$ kdump| grep unveil
 10140 endlessh CALL  unveil(0xe5d37d676d7,0xe5d37d674ea)
 10140 endlessh RET   unveil 0
 10140 endlessh STRU  promise="inet stdio rpath unveil"
```

While ps reports: `10140 S+pu   p4    0:00.00 ./endlessh`

Notice only `u`. (this is not good)

### After patch (without default config and no default config)

```
$ ktrace ./endlessh
^C
$ kdump| grep unveil
 83117 endlessh CALL  unveil(0x2dbba65d486,0x2dbba65d396)
 83117 endlessh RET   unveil 0
 83117 endlessh CALL  unveil(0x2dbba65d6da,0x2dbba65d4ed)
 83117 endlessh RET   unveil -1 errno 2 No such file or directory
 83117 endlessh STRU  promise="inet stdio rpath unveil"
 83117 endlessh CALL  unveil(0,0)
 83117 endlessh RET   unveil 0
```

While ps reports: `83117 S+pU   p4    0:00.00 ./endlessh` (with the `U`. yay)
</details>