### PR TITLE
Fix systemd unit namespace issue (fixes: #53, #58, #68, #100)

### DIFF
--- a/util/endlessh.service
+++ b/util/endlessh.service
@@ -22,7 +22,7 @@ PrivateTmp=true
 PrivateDevices=true
 ProtectSystem=full
 ProtectHome=true
-InaccessiblePaths=/run /var
+InaccessiblePaths=/var
 
 ## If you want Endlessh to bind on ports < 1024
 ## 1) run: 


### PR DESCRIPTION
Fix systemd unit namespace issue (fixes: #53, #58, #68, #100)

Without this change, the systemd unit would fail like this:
```
# systemctl start endlessh
# journalctl -u endlessh -b
Feb 14 11:08:58 batou systemd[1]: Started endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:08:58 batou systemd[1]: endlessh.service: Main process exited, code=exited, status=226/NAMESPACE
Feb 14 11:08:58 batou systemd[1]: endlessh.service: Failed with result 'exit-code'.
Feb 14 11:09:28 batou systemd[1]: endlessh.service: Scheduled restart job, restart counter is at 1.
Feb 14 11:09:28 batou systemd[1]: Stopped endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:09:28 batou systemd[1]: Started endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:09:28 batou systemd[1]: endlessh.service: Main process exited, code=exited, status=226/NAMESPACE
Feb 14 11:09:28 batou systemd[1]: endlessh.service: Failed with result 'exit-code'.
Feb 14 11:09:58 batou systemd[1]: endlessh.service: Scheduled restart job, restart counter is at 2.
Feb 14 11:09:58 batou systemd[1]: Stopped endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:09:58 batou systemd[1]: Started endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:09:58 batou systemd[1]: endlessh.service: Main process exited, code=exited, status=226/NAMESPACE
Feb 14 11:09:58 batou systemd[1]: endlessh.service: Failed with result 'exit-code'.
Feb 14 11:10:28 batou systemd[1]: endlessh.service: Scheduled restart job, restart counter is at 3.
Feb 14 11:10:28 batou systemd[1]: Stopped endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:10:28 batou systemd[1]: Started endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:10:29 batou systemd[1]: endlessh.service: Main process exited, code=exited, status=226/NAMESPACE
Feb 14 11:10:29 batou systemd[1]: endlessh.service: Failed with result 'exit-code'.
Feb 14 11:10:59 batou systemd[1]: endlessh.service: Scheduled restart job, restart counter is at 4.
Feb 14 11:10:59 batou systemd[1]: Stopped endlessh.service - Endlessh SSH Tarpit.
Feb 14 11:10:59 batou systemd[1]: endlessh.service: Start request repeated too quickly.
Feb 14 11:10:59 batou systemd[1]: endlessh.service: Failed with result 'exit-code'.
Feb 14 11:10:59 batou systemd[1]: Failed to start endlessh.service - Endlessh SSH Tarpit.
```

With this change, starting endlessh.service succeeds:
```
# systemctl start endlessh
# journalctl -u endlessh -b
[...]
Feb 14 11:15:08 batou systemd[1]: Started endlessh.service - Endlessh SSH Tarpit.
```

This change was tested on Debian trixie, up-to-date as of 2025-02-14.
